### PR TITLE
Add support for zod/v4

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ deno add jsr:@keawade/zod-env
 
 ```ts
 import { parseEnv } from "jsr:@keawade/zod-env";
+// or, for zod/v4
+import { parseEnv } from "jsr:@keawade/zod-env/v4";
 
 const envSchema = z.object({
   FOO: z.string(),

--- a/deno.json
+++ b/deno.json
@@ -5,14 +5,17 @@
     "include": ["README.md", "LICENSE", "deno.json", "deno.lock", "**/*.ts"],
     "exclude": ["**/*.test.ts"]
   },
-  "exports": "./mod.ts",
+  "exports": {
+    ".": "./mod.ts",
+    "./v4": "./v4/mod.ts"
+  },
   "tasks": {
     "test": "deno test --allow-env=TEST_FOO,TEST_BAR,TEST_BAZ",
     "test:watch": "deno test --allow-env=TEST_FOO,TEST_BAR,TEST_BAZ --watch"
   },
   "imports": {
-    "@std/expect": "jsr:@std/expect@^1.0.6",
-    "@std/testing": "jsr:@std/testing@^1.0.3",
-    "zod": "npm:zod@^3.23.8"
+    "@std/expect": "jsr:@std/expect@^1.0.16",
+    "@std/testing": "jsr:@std/testing@^1.0.14",
+    "zod": "npm:zod@^3.25.64"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -1,66 +1,70 @@
 {
-  "version": "4",
+  "version": "5",
   "specifiers": {
-    "jsr:@std/assert@^1.0.6": "1.0.6",
-    "jsr:@std/data-structures@^1.0.4": "1.0.4",
-    "jsr:@std/expect@^1.0.6": "1.0.6",
-    "jsr:@std/fs@^1.0.4": "1.0.5",
-    "jsr:@std/internal@^1.0.4": "1.0.4",
-    "jsr:@std/path@^1.0.6": "1.0.7",
-    "jsr:@std/path@^1.0.7": "1.0.7",
-    "jsr:@std/testing@^1.0.3": "1.0.3",
-    "npm:zod@^3.23.8": "3.23.8"
+    "jsr:@std/assert@^1.0.13": "1.0.13",
+    "jsr:@std/data-structures@^1.0.8": "1.0.8",
+    "jsr:@std/expect@*": "1.0.16",
+    "jsr:@std/expect@^1.0.16": "1.0.16",
+    "jsr:@std/fs@^1.0.18": "1.0.18",
+    "jsr:@std/internal@^1.0.6": "1.0.8",
+    "jsr:@std/internal@^1.0.7": "1.0.8",
+    "jsr:@std/internal@^1.0.8": "1.0.8",
+    "jsr:@std/path@^1.1.0": "1.1.0",
+    "jsr:@std/testing@*": "1.0.14",
+    "jsr:@std/testing@^1.0.14": "1.0.14",
+    "npm:zod@3": "3.25.64",
+    "npm:zod@^3.25.64": "3.25.64"
   },
   "jsr": {
-    "@std/assert@1.0.6": {
-      "integrity": "1904c05806a25d94fe791d6d883b685c9e2dcd60e4f9fc30f4fc5cf010c72207",
+    "@std/assert@1.0.13": {
+      "integrity": "ae0d31e41919b12c656c742b22522c32fb26ed0cba32975cb0de2a273cb68b29",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.6"
       ]
     },
-    "@std/data-structures@1.0.4": {
-      "integrity": "fa0e20c11eb9ba673417450915c750a0001405a784e2a4e0c3725031681684a0"
+    "@std/data-structures@1.0.8": {
+      "integrity": "2fb7219247e044c8fcd51341788547575653c82ae2c759ff209e0263ba7d9b66"
     },
-    "@std/expect@1.0.6": {
-      "integrity": "dffba969ca5ea6d7c39338d4985c9af2bfa6e080c710cc2b77756dd7657c369c",
+    "@std/expect@1.0.16": {
+      "integrity": "ceeef6dda21f256a5f0f083fcc0eaca175428b523359a9b1d9b3a1df11cc7391",
       "dependencies": [
         "jsr:@std/assert",
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.7"
       ]
     },
-    "@std/fs@1.0.5": {
-      "integrity": "41806ad6823d0b5f275f9849a2640d87e4ef67c51ee1b8fb02426f55e02fd44e",
+    "@std/fs@1.0.18": {
+      "integrity": "24bcad99eab1af4fde75e05da6e9ed0e0dce5edb71b7e34baacf86ffe3969f3a",
       "dependencies": [
-        "jsr:@std/path@^1.0.7"
+        "jsr:@std/path"
       ]
     },
-    "@std/internal@1.0.4": {
-      "integrity": "62e8e4911527e5e4f307741a795c0b0a9e6958d0b3790716ae71ce085f755422"
+    "@std/internal@1.0.8": {
+      "integrity": "fc66e846d8d38a47cffd274d80d2ca3f0de71040f855783724bb6b87f60891f5"
     },
-    "@std/path@1.0.7": {
-      "integrity": "76a689e07f0e15dcc6002ec39d0866797e7156629212b28f27179b8a5c3b33a1"
+    "@std/path@1.1.0": {
+      "integrity": "ddc94f8e3c275627281cbc23341df6b8bcc874d70374f75fec2533521e3d6886"
     },
-    "@std/testing@1.0.3": {
-      "integrity": "f98c2bee53860a5916727d7e7d3abe920dd6f9edace022e2d059f00d05c2cf42",
+    "@std/testing@1.0.14": {
+      "integrity": "144b3737105b9071cb50c957681f58a1b8ec0f3e5b19ad830f401c5fa931e8f0",
       "dependencies": [
         "jsr:@std/assert",
         "jsr:@std/data-structures",
         "jsr:@std/fs",
-        "jsr:@std/internal",
-        "jsr:@std/path@^1.0.6"
+        "jsr:@std/internal@^1.0.8",
+        "jsr:@std/path"
       ]
     }
   },
   "npm": {
-    "zod@3.23.8": {
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="
+    "zod@3.25.64": {
+      "integrity": "sha512-hbP9FpSZf7pkS7hRVUrOjhwKJNyampPgtXKc3AN6DsWtoHsg2Sb4SQaS4Tcay380zSwd2VPo9G9180emBACp5g=="
     }
   },
   "workspace": {
     "dependencies": [
-      "jsr:@std/expect@^1.0.6",
-      "jsr:@std/testing@^1.0.3",
-      "npm:zod@^3.23.8"
+      "jsr:@std/expect@^1.0.16",
+      "jsr:@std/testing@^1.0.14",
+      "npm:zod@^3.25.64"
     ]
   }
 }

--- a/v4/mod.ts
+++ b/v4/mod.ts
@@ -1,0 +1,1 @@
+export { parseEnv } from "./parseEnv.ts";

--- a/v4/parseEnv.test.ts
+++ b/v4/parseEnv.test.ts
@@ -1,0 +1,105 @@
+import { expect } from "jsr:@std/expect";
+import { afterAll, beforeAll, describe, it } from "jsr:@std/testing/bdd";
+import { z } from "npm:zod@3/v4";
+
+import { parseEnv } from "./parseEnv.ts";
+
+describe("validateEnv", () => {
+  const testEnv: Record<string, string> = {
+    TEST_FOO: "foo",
+    TEST_BAR: "42",
+    TEST_BAZ: "false",
+  };
+
+  beforeAll(() => {
+    for (const name in testEnv) {
+      Deno.env.set(name, testEnv[name]);
+    }
+  });
+
+  afterAll(() => {
+    for (const name in testEnv) {
+      Deno.env.delete(name);
+    }
+  });
+
+  it("should throw an error if schema does not extend z.object", () => {
+    expect.hasAssertions();
+
+    try {
+      parseEnv(z.string() as any);
+    } catch (err: any) {
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toBe("Invalid schema. Must extend z.object.");
+    }
+  });
+
+  it("should handle empty schema", () => {
+    const actual = parseEnv(z.object({}));
+
+    expect(actual).toEqual({});
+  });
+
+  it("should only get requested env vars", () => {
+    expect(
+      Deno.permissions.querySync({ name: "env", variable: "TEST_FOO" })
+        .state,
+      "Expected env.TEST_FOO permissions for this test!",
+    ).toBe("granted");
+    expect(
+      Deno.permissions.querySync({
+        name: "env",
+        variable: "TEST_BAR",
+      })
+        .state,
+      "Expected env.TEST_BAR permissions for this test!",
+    ).toBe("granted");
+    expect(
+      Deno.permissions.querySync({
+        name: "env",
+        variable: "TEST_BAZ",
+      })
+        .state,
+      "Expected env.TEST_BAZ permissions for this test!",
+    ).toBe("granted");
+
+    const actual = parseEnv(
+      z.object({
+        TEST_FOO: z.string(),
+        TEST_BAR: z.coerce.number(),
+        TEST_BAZ: z.enum(["true", "false"]).transform((val) => val === "true"),
+      }),
+    );
+
+    expect(actual).toEqual({
+      TEST_FOO: "foo",
+      TEST_BAR: 42,
+      TEST_BAZ: false,
+    });
+  });
+
+  it("should fallback to default or optional if denied permissions", () => {
+    expect(
+      Deno.permissions.querySync({ name: "env", variable: "TEST_NOT_ALLOWED" })
+        .state,
+    ).toBe("prompt");
+    expect(
+      Deno.permissions.querySync({
+        name: "env",
+        variable: "TEST_ALSO_NOT_ALLOWED",
+      })
+        .state,
+    ).toBe("prompt");
+
+    const actual = parseEnv(
+      z.object({
+        TEST_NOT_ALLOWED: z.string().default("It's okay."),
+        TEST_ALSO_NOT_ALLOWED: z.string().optional(),
+      }),
+    );
+
+    expect(actual).toEqual({
+      TEST_NOT_ALLOWED: "It's okay.",
+    });
+  });
+});

--- a/v4/parseEnv.ts
+++ b/v4/parseEnv.ts
@@ -1,0 +1,38 @@
+import type {
+  infer as zInfer,
+  ZodObject,
+} from "npm:zod@3/v4";
+
+/**
+ * This function parses the current environment's variables using the provided
+ * Zod schema.
+ *
+ * Environment variable permissions are requested individually so usage is
+ * clear.
+ *
+ * Environment variable permissions can be refused without error for optional
+ * values in the schema or when a default value is provided by the schema.
+ *
+ * @param schema The Zod schema to use to parse the environment variables.
+ * @returns Parsed environment variables.
+ */
+export const parseEnv = <
+  T extends ZodObject,
+>(schema: T): zInfer<typeof schema> => {
+  if (schema._zod.def.type !== "object") {
+    throw new Error("Invalid schema. Must extend z.object.");
+  }
+
+  // Populate object to validate
+  const vars: Record<string, string | undefined> = {};
+  for (const key in schema.shape) {
+    if (
+      Deno.permissions.requestSync({ name: "env", variable: key }).state ===
+      "granted"
+    ) {
+      vars[key] = Deno.env.get(key);
+    }
+  }
+
+  return schema.parse(vars);
+};


### PR DESCRIPTION
This PR adds support for [zod/v4](https://zod.dev/v4). I used the same namespacing technique that zod itself used. That way no changes are made to existing projects, but the user can `import {parseEnv} from "@keawade/zod-env/v4" if they want to use zod/v4. It could probably be combined into a single function that supports v3 and v4, but I thought it would be cleaner to keep things separate. 

The reason I wanted to do this is the Deno LSP keeps running out of memory in my current project. Right now, it gives up parsing my z.object for my env because it is "excessively deep and possibly infinite". zod v4 is supposed to be much lighter on the typescript compiler, so hopefully this will fix it. Also I am using v4 everywhere else in my project, so it would be nice to use the new syntax everywhere. 